### PR TITLE
bugfix: do not cache masthead, which includes language menu

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,7 @@
   <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}">
     {% include_cached skip-links.html %}
     {% include_cached browser-upgrade.html %}
-    {% include_cached masthead.html page = page %}
+    {% include masthead.html page = page %}
 
     <div class="initial-content">
       {{ content }}


### PR DESCRIPTION
in addition to ca9db0ba6ef5b0d50b6ac06933284376d25a4d66